### PR TITLE
Force tomcat v8.0.28

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -16,7 +16,7 @@
 # Configuration for the Tomcat container
 ---
 tomcat8:
-  version: 8.0.+
+  version: 8.0.28
   repository_root: ! '{default.repository.root}/tomcat'
 tomcat7:
   version: 7.0.+


### PR DESCRIPTION
IDM team is having issues with their application and they think it is caused by tomcat 8.0.30. This will force the buildpack to use 8.0.28 which is what all apps in US datacenter use.
